### PR TITLE
share topIndex policy in revese method with discard one

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -242,14 +242,15 @@ public class CardStackView extends RelativeLayout {
 
     public void reverse() {
         if (lastDirection != null) {
-            topIndex--;
 
             ViewGroup parent = containers.get(0);
-            View prevView = adapter.getView(topIndex, null, parent);
+            View prevView = adapter.getView(topIndex - 1, null, parent);
             cardAnimator.reverse(lastDirection, prevView, new AnimatorListenerAdapter() {
                 @Override
                 public void onAnimationEnd(Animator animation) {
                     lastDirection = null;
+
+                    topIndex--;
 
                     containers.get(0).setOnTouchListener(null);
                     containers.get(containers.size() - 1)


### PR DESCRIPTION
Top index status is different between CardStackView#discard with CardStackView#revese.
This cause a little confusing use, we get invisible card index if we use getTopIndex method just after executing reverse method, but on the other hand, we get visible card index if we do just after executing discard.

Well,I would like you to define the policy of `topIndex`.  I'm confused when use getTopIndex around discard interface or reverse method. if the `top` means the card stack top, top index has been already changed just before animation starts. if the `top` means the visible card top including animating, the top index should be changed only after animate end.

I'm looking forward your idea.

Thanks.


