### PR TITLE
Disallow parent layout to intercept touches.

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -13,7 +13,7 @@ import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
+import android.widget.BaseAdapter;
 import android.widget.FrameLayout;
 
 import com.yuyakaido.android.cardstackview.internal.CardContainerView;
@@ -37,7 +37,7 @@ public class CardStackView extends FrameLayout {
     private CardStackOption option = new CardStackOption();
     private CardStackState state = new CardStackState();
 
-    private ArrayAdapter<?> adapter = null;
+    private BaseAdapter adapter = null;
     private LinkedList<CardContainerView> containers = new LinkedList<>();
     private CardEventListener cardEventListener = null;
     private DataSetObserver dataSetObserver = new DataSetObserver() {
@@ -367,7 +367,7 @@ public class CardStackView extends FrameLayout {
         this.cardEventListener = listener;
     }
 
-    public void setAdapter(ArrayAdapter<?> adapter) {
+    public void setAdapter(BaseAdapter adapter) {
         if (this.adapter != null) {
             this.adapter.unregisterDataSetObserver(dataSetObserver);
         }

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardContainerView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardContainerView.java
@@ -84,9 +84,14 @@ public class CardContainerView extends FrameLayout {
         switch (MotionEventCompat.getActionMasked(event)) {
             case MotionEvent.ACTION_DOWN:
                 handleActionDown(event);
+                getParent().getParent().requestDisallowInterceptTouchEvent(true);
                 break;
             case MotionEvent.ACTION_UP:
                 handleActionUp(event);
+                getParent().getParent().requestDisallowInterceptTouchEvent(false);
+                break;
+            case MotionEvent.ACTION_CANCEL:
+                getParent().getParent().requestDisallowInterceptTouchEvent(false);
                 break;
             case MotionEvent.ACTION_MOVE:
                 handleActionMove(event);


### PR DESCRIPTION
This resolves problem with ViewPager intercepting touches meant to be handled by CardContainerView. before this any moves along x axis would work for a few frames and then hang the card in mid-swipe and start changing ViewPager page