### PR TITLE
Make adapter.notifyDataSetChanged() less aggressive.

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -50,7 +50,11 @@ public class CardStackView extends FrameLayout {
                 boolean isSameCount = state.lastCount == adapter.getCount();
                 shouldReset = !isSameCount;
             }
-            initialize(shouldReset);
+            if (shouldReset) {
+                initialize(true);
+            } else {
+                initializeViewContents();
+            }
             state.lastCount = adapter.getCount();
         }
     };


### PR DESCRIPTION
At the moment, if we call `notifyDataSetChanged()` on our adapter, then CardStackView unconditionally recreates all of the Views that are shown in the list. In other words, there's never a case when `adapter.getView()` gets called with a recycled contentView that can be reused for fresh content.

This patch lightens the operation of the `onChanged()` handler, where it will now reuse any Views that are already created, and no longer recreate the entire list.