### PR TITLE
Support swipe direction `none` value

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -336,7 +336,7 @@ public class CardStackView extends FrameLayout {
 
     private void executePostSwipeTask(Point point, SwipeDirection direction) {
         // don't swipe card if swipeDirection is updated to lock this direction when the card is moving
-        if (!option.swipeDirection.contains(direction)) {
+        if (option.swipeDirection.isEmpty()) {
             return;
         }
 

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -328,6 +328,11 @@ public class CardStackView extends FrameLayout {
     }
 
     private void executePostSwipeTask(Point point, SwipeDirection direction) {
+        // don't swipe card if swipeDirection is updated to lock this direction when the card is moving
+        if (!option.swipeDirection.contains(direction)) {
+            return;
+        }
+
         reorderForSwipe();
 
         state.lastPoint = point;

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -262,16 +262,16 @@ public class CardStackView extends FrameLayout {
     }
 
     public void performSwipe(SwipeDirection direction, AnimatorSet set, final Animator.AnimatorListener listener) {
-        if (direction == SwipeDirection.Left) {
+        if (direction == SwipeDirection.LEFT) {
             getTopView().showLeftOverlay();
             getTopView().setOverlayAlpha(1f);
-        } else if (direction == SwipeDirection.Right) {
+        } else if (direction == SwipeDirection.RIGHT) {
             getTopView().showRightOverlay();
             getTopView().setOverlayAlpha(1f);
-        } else if (direction == SwipeDirection.Bottom){
+        } else if (direction == SwipeDirection.BOTTOM) {
             getTopView().showBottomOverlay();
             getTopView().setOverlayAlpha(1f);
-        } else if (direction == SwipeDirection.Top){
+        } else if (direction == SwipeDirection.TOP) {
             getTopView().showTopOverlay();
             getTopView().setOverlayAlpha(1f);
         }

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/SwipeDirection.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/SwipeDirection.java
@@ -1,5 +1,6 @@
 package com.yuyakaido.android.cardstackview;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -9,11 +10,12 @@ public enum SwipeDirection {
     public static final List<SwipeDirection> FREEDOM = Arrays
             .asList(SwipeDirection.values());
     public static final List<SwipeDirection> FREEDOM_NO_BOTTOM = Arrays
-            .asList(SwipeDirection.Top,SwipeDirection.Left, SwipeDirection.Right);
+            .asList(SwipeDirection.Top, SwipeDirection.Left, SwipeDirection.Right);
     public static final List<SwipeDirection> HORIZONTAL = Arrays
             .asList(SwipeDirection.Left, SwipeDirection.Right);
     public static final List<SwipeDirection> VERTICAL = Arrays
             .asList(SwipeDirection.Top, SwipeDirection.Bottom);
+    public static final List<SwipeDirection> NONE = new ArrayList<>();
 
     public static List<SwipeDirection> from(int value) {
         switch (value) {
@@ -25,6 +27,8 @@ public enum SwipeDirection {
                 return HORIZONTAL;
             case 3:
                 return VERTICAL;
+            case 4:
+                return NONE;
             default:
                 return FREEDOM;
         }

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/SwipeDirection.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/SwipeDirection.java
@@ -5,16 +5,16 @@ import java.util.Arrays;
 import java.util.List;
 
 public enum SwipeDirection {
-    Left, Right, Top, Bottom;
+    LEFT, RIGHT, TOP, BOTTOM;
 
     public static final List<SwipeDirection> FREEDOM = Arrays
             .asList(SwipeDirection.values());
     public static final List<SwipeDirection> FREEDOM_NO_BOTTOM = Arrays
-            .asList(SwipeDirection.Top, SwipeDirection.Left, SwipeDirection.Right);
+            .asList(SwipeDirection.TOP, SwipeDirection.LEFT, SwipeDirection.RIGHT);
     public static final List<SwipeDirection> HORIZONTAL = Arrays
-            .asList(SwipeDirection.Left, SwipeDirection.Right);
+            .asList(SwipeDirection.LEFT, SwipeDirection.RIGHT);
     public static final List<SwipeDirection> VERTICAL = Arrays
-            .asList(SwipeDirection.Top, SwipeDirection.Bottom);
+            .asList(SwipeDirection.TOP, SwipeDirection.BOTTOM);
     public static final List<SwipeDirection> NONE = new ArrayList<>();
 
     public static List<SwipeDirection> from(int value) {

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardContainerView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardContainerView.java
@@ -311,7 +311,7 @@ public class CardContainerView extends FrameLayout {
     }
 
     public void showLeftOverlay() {
-        if (leftOverlayView != null) {
+        if (leftOverlayView != null && option.swipeDirection.contains(SwipeDirection.Left)) {
             ViewCompat.setAlpha(leftOverlayView, 1f);
         }
         if (rightOverlayView != null) {
@@ -338,7 +338,7 @@ public class CardContainerView extends FrameLayout {
             ViewCompat.setAlpha(topOverlayView, 0f);
         }
 
-        if (rightOverlayView != null) {
+        if (rightOverlayView != null && option.swipeDirection.contains(SwipeDirection.Right)) {
             ViewCompat.setAlpha(rightOverlayView, 1f);
         }
     }
@@ -348,7 +348,7 @@ public class CardContainerView extends FrameLayout {
             ViewCompat.setAlpha(leftOverlayView, 0f);
         }
 
-        if (bottomOverlayView != null) {
+        if (bottomOverlayView != null && option.swipeDirection.contains(SwipeDirection.Bottom)) {
             ViewCompat.setAlpha(bottomOverlayView, 1f);
         }
 
@@ -371,7 +371,7 @@ public class CardContainerView extends FrameLayout {
             ViewCompat.setAlpha(bottomOverlayView, 0f);
         }
 
-        if (topOverlayView != null) {
+        if (topOverlayView != null && option.swipeDirection.contains(SwipeDirection.Top)) {
             ViewCompat.setAlpha(topOverlayView, 1f);
         }
 

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardContainerView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardContainerView.java
@@ -124,18 +124,18 @@ public class CardContainerView extends FrameLayout {
                     degree = 180 - degree;
                     radian = Math.toRadians(degree);
                     if (Math.cos(radian) < -0.5) {
-                        direction = SwipeDirection.Left;
+                        direction = SwipeDirection.LEFT;
                     } else {
-                        direction = SwipeDirection.Top;
+                        direction = SwipeDirection.TOP;
                     }
                     break;
                 case TopRight:
                     degree = Math.toDegrees(radian);
                     radian = Math.toRadians(degree);
                     if (Math.cos(radian) < 0.5) {
-                        direction = SwipeDirection.Top;
+                        direction = SwipeDirection.TOP;
                     } else {
-                        direction = SwipeDirection.Right;
+                        direction = SwipeDirection.RIGHT;
                     }
                     break;
                 case BottomLeft:
@@ -143,9 +143,9 @@ public class CardContainerView extends FrameLayout {
                     degree = 180 + degree;
                     radian = Math.toRadians(degree);
                     if (Math.cos(radian) < -0.5) {
-                        direction = SwipeDirection.Left;
+                        direction = SwipeDirection.LEFT;
                     } else {
-                        direction = SwipeDirection.Bottom;
+                        direction = SwipeDirection.BOTTOM;
                     }
                     break;
                 case BottomRight:
@@ -153,15 +153,15 @@ public class CardContainerView extends FrameLayout {
                     degree = 360 - degree;
                     radian = Math.toRadians(degree);
                     if (Math.cos(radian) < 0.5) {
-                        direction = SwipeDirection.Bottom;
-                    }else{
-                        direction = SwipeDirection.Right;
+                        direction = SwipeDirection.BOTTOM;
+                    } else {
+                        direction = SwipeDirection.RIGHT;
                     }
                     break;
             }
 
             float percent = 0f;
-            if (direction == SwipeDirection.Left || direction == SwipeDirection.Right) {
+            if (direction == SwipeDirection.LEFT || direction == SwipeDirection.RIGHT) {
                 percent = getPercentX();
             } else {
                 percent = getPercentY();
@@ -311,7 +311,7 @@ public class CardContainerView extends FrameLayout {
     }
 
     public void showLeftOverlay() {
-        if (leftOverlayView != null && option.swipeDirection.contains(SwipeDirection.Left)) {
+        if (leftOverlayView != null && option.swipeDirection.contains(SwipeDirection.LEFT)) {
             ViewCompat.setAlpha(leftOverlayView, 1f);
         }
         if (rightOverlayView != null) {
@@ -338,7 +338,7 @@ public class CardContainerView extends FrameLayout {
             ViewCompat.setAlpha(topOverlayView, 0f);
         }
 
-        if (rightOverlayView != null && option.swipeDirection.contains(SwipeDirection.Right)) {
+        if (rightOverlayView != null && option.swipeDirection.contains(SwipeDirection.RIGHT)) {
             ViewCompat.setAlpha(rightOverlayView, 1f);
         }
     }
@@ -348,7 +348,7 @@ public class CardContainerView extends FrameLayout {
             ViewCompat.setAlpha(leftOverlayView, 0f);
         }
 
-        if (bottomOverlayView != null && option.swipeDirection.contains(SwipeDirection.Bottom)) {
+        if (bottomOverlayView != null && option.swipeDirection.contains(SwipeDirection.BOTTOM)) {
             ViewCompat.setAlpha(bottomOverlayView, 1f);
         }
 
@@ -371,7 +371,7 @@ public class CardContainerView extends FrameLayout {
             ViewCompat.setAlpha(bottomOverlayView, 0f);
         }
 
-        if (topOverlayView != null && option.swipeDirection.contains(SwipeDirection.Top)) {
+        if (topOverlayView != null && option.swipeDirection.contains(SwipeDirection.TOP)) {
             ViewCompat.setAlpha(topOverlayView, 1f);
         }
 

--- a/cardstackview/src/main/res/values/attrs.xml
+++ b/cardstackview/src/main/res/values/attrs.xml
@@ -17,6 +17,7 @@
             <enum name="freedom_no_bottom" value="1"/>
             <enum name="horizontal" value="2"/>
             <enum name="vertical" value="3"/>
+            <enum name="none" value="4" />
         </attr>
         <attr name="leftOverlay" format="reference"/>
         <attr name="rightOverlay" format="reference"/>

--- a/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/MainActivity.java
+++ b/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/MainActivity.java
@@ -223,7 +223,7 @@ public class MainActivity extends AppCompatActivity {
         AnimatorSet set = new AnimatorSet();
         set.playTogether(rotation, translateX, translateY);
 
-        cardStackView.swipe(SwipeDirection.Left, set);
+        cardStackView.swipe(SwipeDirection.LEFT, set);
     }
 
     public void swipeRight() {
@@ -248,7 +248,7 @@ public class MainActivity extends AppCompatActivity {
         AnimatorSet set = new AnimatorSet();
         set.playTogether(rotation, translateX, translateY);
 
-        cardStackView.swipe(SwipeDirection.Right, set);
+        cardStackView.swipe(SwipeDirection.RIGHT, set);
     }
 
     private void reverse() {


### PR DESCRIPTION
- Use `app:swipeDirection="none"` to enable swiping without direction (same to card locking). Card is auto moving to origin position whatever direction is.
- Card overlay also is available if there is corresponding swipe direction. That means if set swipe direction to `none`, when moving the card, the overlay will be disabled.