### PR TITLE
Support multiple view types.

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -179,6 +179,9 @@ public class CardStackView extends FrameLayout {
             container.setDraggable(false);
             ViewGroup parent = container.getContentContainer();
             View child = adapter.getView(lastIndex, parent.getChildAt(0), parent);
+            if (parent.getChildCount() != 0 && !parent.getChildAt(0).getTag().equals(child)) {
+                parent.removeViewAt(0);
+            }
             if (parent.getChildCount() == 0) {
                 parent.addView(child);
             }

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -179,7 +179,7 @@ public class CardStackView extends FrameLayout {
             container.setDraggable(false);
             ViewGroup parent = container.getContentContainer();
             View child = adapter.getView(lastIndex, parent.getChildAt(0), parent);
-            if (parent.getChildCount() != 0 && !parent.getChildAt(0).getTag().equals(child.getTag())) {
+            if (parent.getChildCount() != 0 && isTagsDifferent(child,parent.getChildAt(0))) {
                 parent.removeViewAt(0);
             }
             if (parent.getChildCount() == 0) {
@@ -195,6 +195,10 @@ public class CardStackView extends FrameLayout {
         if (hasCard) {
             getTopView().setDraggable(true);
         }
+    }
+
+    private boolean isTagsDifferent(View oldView, View newView) {
+        return !(oldView.getTag() == null ? newView.getTag() == null : newView.getTag().equals(oldView.getTag()));
     }
 
     private void clear() {

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -179,7 +179,7 @@ public class CardStackView extends FrameLayout {
             container.setDraggable(false);
             ViewGroup parent = container.getContentContainer();
             View child = adapter.getView(lastIndex, parent.getChildAt(0), parent);
-            if (parent.getChildCount() != 0 && !parent.getChildAt(0).getTag().equals(child)) {
+            if (parent.getChildCount() != 0 && !parent.getChildAt(0).getTag().equals(child.getTag())) {
                 parent.removeViewAt(0);
             }
             if (parent.getChildCount() == 0) {


### PR DESCRIPTION
We encountered a problem ,
when you have multiple view types defined in the adapter with multiple view holders.
If the view got recycled but the new child is a different type it's got ignored.

In the fix I compare the existing child with the new one and if the viewHolder is different i drop the previous child.