### PR TITLE
Fixed card height and width

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.java
@@ -225,6 +225,12 @@ public class CardStackLayoutManager
         final int parentBottom = getHeight() - getPaddingBottom();
         for (int i = state.topPosition; i < state.topPosition + setting.visibleCount && i < getItemCount(); i++) {
             View child = recycler.getViewForPosition(i);
+
+            ViewGroup.LayoutParams params = child.getLayoutParams();
+            params.width = parentRight - parentLeft;
+            params.height = parentBottom - parentTop - getPaddingTop() - getPaddingBottom();
+            child.setLayoutParams(params);
+
             addView(child, 0);
             measureChildWithMargins(child, 0, 0);
             layoutDecoratedWithMargins(child, parentLeft, parentTop, parentRight, parentBottom);


### PR DESCRIPTION
Sets the size of the card equals the size of recyclerview container.

**Problem:** If the RecyclerView contains paddings the cardviews are bigger that the container and content are cutted.