### PR TITLE
Migrate support library dependencies to androidx

### DIFF
--- a/cardstackview/build.gradle
+++ b/cardstackview/build.gradle
@@ -32,5 +32,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
 }

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.java
@@ -3,13 +3,14 @@ package com.yuyakaido.android.cardstackview;
 import android.content.Context;
 import android.graphics.PointF;
 import android.os.Handler;
-import android.support.annotation.FloatRange;
-import android.support.annotation.IntRange;
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Interpolator;
+
+import androidx.annotation.FloatRange;
+import androidx.annotation.IntRange;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.yuyakaido.android.cardstackview.internal.CardStackSetting;
 import com.yuyakaido.android.cardstackview.internal.CardStackSmoothScroller;

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackView.java
@@ -1,10 +1,11 @@
 package com.yuyakaido.android.cardstackview;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
-import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.yuyakaido.android.cardstackview.internal.CardStackDataObserver;
 import com.yuyakaido.android.cardstackview.internal.CardStackSnapHelper;

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackDataObserver.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackDataObserver.java
@@ -1,7 +1,7 @@
 package com.yuyakaido.android.cardstackview.internal;
 
-import android.support.annotation.Nullable;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.yuyakaido.android.cardstackview.CardStackLayoutManager;
 

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSmoothScroller.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSmoothScroller.java
@@ -1,8 +1,9 @@
 package com.yuyakaido.android.cardstackview.internal;
 
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.yuyakaido.android.cardstackview.CardStackLayoutManager;
 import com.yuyakaido.android.cardstackview.CardStackListener;

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSnapHelper.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSnapHelper.java
@@ -1,10 +1,11 @@
 package com.yuyakaido.android.cardstackview.internal;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.SnapHelper;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.SnapHelper;
 
 import com.yuyakaido.android.cardstackview.CardStackLayoutManager;
 import com.yuyakaido.android.cardstackview.Duration;

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackState.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackState.java
@@ -1,6 +1,6 @@
 package com.yuyakaido.android.cardstackview.internal;
 
-import android.support.v7.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.yuyakaido.android.cardstackview.Direction;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -25,10 +25,10 @@ dependencies {
     kapt 'com.github.bumptech.glide:compiler:4.9.0'
 
     // Support Library
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
-    implementation 'com.android.support:cardview-v7:28.0.0'
-    implementation 'com.android.support:design:28.0.0'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
 
     // View
     implementation 'com.makeramen:roundedimageview:2.3.0'

--- a/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/CardStackAdapter.kt
+++ b/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/CardStackAdapter.kt
@@ -1,12 +1,12 @@
 package com.yuyakaido.android.cardstackview.sample
 
-import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 
 class CardStackAdapter(

--- a/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/MainActivity.kt
+++ b/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/MainActivity.kt
@@ -1,13 +1,6 @@
 package com.yuyakaido.android.cardstackview.sample
 
 import android.os.Bundle
-import android.support.design.widget.NavigationView
-import android.support.v4.widget.DrawerLayout
-import android.support.v7.app.ActionBarDrawerToggle
-import android.support.v7.app.AppCompatActivity
-import android.support.v7.util.DiffUtil
-import android.support.v7.widget.DefaultItemAnimator
-import android.support.v7.widget.Toolbar
 import android.util.Log
 import android.view.Gravity
 import android.view.View
@@ -15,6 +8,13 @@ import android.view.animation.AccelerateInterpolator
 import android.view.animation.DecelerateInterpolator
 import android.view.animation.LinearInterpolator
 import android.widget.TextView
+import androidx.appcompat.app.ActionBarDrawerToggle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.DiffUtil
+import com.google.android.material.navigation.NavigationView
 import com.yuyakaido.android.cardstackview.*
 import java.util.*
 

--- a/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/SpotDiffCallback.kt
+++ b/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/SpotDiffCallback.kt
@@ -1,6 +1,6 @@
 package com.yuyakaido.android.cardstackview.sample
 
-import android.support.v7.util.DiffUtil
+import androidx.recyclerview.widget.DiffUtil
 
 class SpotDiffCallback(
         private val old: List<Spot>,

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<android.support.v4.widget.DrawerLayout
+<androidx.drawerlayout.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_layout"
@@ -12,17 +12,17 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <android.support.design.widget.AppBarLayout
+        <com.google.android.material.appbar.AppBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <android.support.v7.widget.Toolbar
+            <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
-            </android.support.v7.widget.Toolbar>
+            </androidx.appcompat.widget.Toolbar>
 
-        </android.support.design.widget.AppBarLayout>
+        </com.google.android.material.appbar.AppBarLayout>
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -38,7 +38,7 @@
                 android:layout_alignParentBottom="true"
                 android:clipChildren="false">
 
-                <android.support.design.widget.FloatingActionButton
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/skip_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -50,7 +50,7 @@
                     app:fabSize="auto"
                     app:rippleColor="#22ED7563"/>
 
-                <android.support.design.widget.FloatingActionButton
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/rewind_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -64,7 +64,7 @@
                     app:fabSize="mini"
                     app:rippleColor="#225BC9FA"/>
 
-                <android.support.design.widget.FloatingActionButton
+                <com.google.android.material.floatingactionbutton.FloatingActionButton
                     android:id="@+id/like_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -91,13 +91,13 @@
 
     </LinearLayout>
 
-    <android.support.design.widget.NavigationView
+    <com.google.android.material.navigation.NavigationView
         android:id="@+id/navigation_view"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:fitsSystemWindows="true"
         app:menu="@menu/navigation_main_activity">
-    </android.support.design.widget.NavigationView>
+    </com.google.android.material.navigation.NavigationView>
 
-</android.support.v4.widget.DrawerLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/sample/src/main/res/layout/item_spot.xml
+++ b/sample/src/main/res/layout/item_spot.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!-- https://qiita.com/ntsk/items/dac92596742e18470a55 -->
-<android.support.v7.widget.CardView
+<androidx.cardview.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -86,4 +86,4 @@
         android:layout_height="match_parent">
     </FrameLayout>
 
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
### Why this change is needed?
[AndroidX](https://developer.android.com/jetpack/androidx) is replacing the Android support library. Client applications for CardStackView can currently use the library by enabling [jetifier](https://developer.android.com/jetpack/androidx/releases/jetifier) within Android Studio, but long term it's probably best to update to AndroidX at the source.

### What has changed in this PR?
- Simply ran the AndroidX migration tool in Android Studio. All `android.support` packages have been replaced with the new `androidx` dependencies.
- Enables `jetifier` in gradle options to allow the sample app to compile. This is required because Glide [is not yet AndroidX compatible](https://github.com/bumptech/glide/issues/3080).

### How to test it?
- [x] Smoke test sample app