### PR TITLE
optimize rewind anim start position

### DIFF
--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSmoothScroller.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/internal/CardStackSmoothScroller.java
@@ -56,7 +56,7 @@ public class CardStackSmoothScroller extends RecyclerView.SmoothScroller {
             action.update(
                     -getDx(setting),
                     -getDy(setting),
-                    setting.getDuration(),
+                    1,
                     setting.getInterpolator()
             );
         }


### PR DESCRIPTION
the original code set the start position for rewind animation by update a scroller action in  `onSeekTargetStep`, but it use `setting.getDuration()` as its duration. So, when it comes to `onTargetFound` which determine the final position the card will animate to, the card may not be at the startPosition at this moment. 

Here I change the `duration` of `scrolling to startPosition action` to 1, to make sure the duration is short enough to make the card be at the startPosition when it comes to `onTargetFound`.