### PR TITLE
Provide swiped position to onCardSwiped event

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ CardStackLayoutManager.setSwipeableMethod(SwipeableMethod.AutomaticAndManual)
 | Method | Description |
 | :---- | :---- |
 | CardStackListener.onCardDragging(Direction direction, float ratio) | This method is called while the card is dragging. |
-| CardStackListener.onCardSwiped(Direction direction) | This method is called when the card is swiped. |
+| CardStackListener.onCardSwiped(Direction direction, int swipedPosition) | This method is called when the card is swiped. |
 | CardStackListener.onCardRewound() | This method is called when the card is rewinded. |
 | CardStackListener.onCardCanceled() | This method is called when the card is dragged less than threshold. |
 | CardStackListener.onCardAppeared(View view, int position) | This method is called when the card appeared. |
@@ -317,7 +317,7 @@ CardStackLayoutManager.setSwipeableMethod(SwipeableMethod.AutomaticAndManual)
 | :---- | :---- |
 | CardStackView.CardEventListener | CardStackListener |
 | onCardDragging(float percentX, float percentY) | onCardDragging(Direction direction, float ratio) |
-| onCardSwiped(SwipeDirection direction) | onCardSwiped(Direction direction) |
+| onCardSwiped(SwipeDirection direction) | onCardSwiped(Direction direction, int swipedPosition) |
 | onCardReversed() | onCardRewound() |
 | onCardMovedToOrigin() | onCardCanceled() |
 | onCardClicked(int index) | This method is no longer provided. Please implement in your item of RecyclerView. |

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackLayoutManager.java
@@ -270,6 +270,7 @@ public class CardStackLayoutManager
             final Direction direction = state.getDirection();
 
             state.next(state.status.toAnimatedStatus());
+            final int swipedPosition = state.topPosition;
             state.topPosition++;
             state.dx = 0;
             state.dy = 0;
@@ -311,7 +312,7 @@ public class CardStackLayoutManager
             new Handler().post(new Runnable() {
                 @Override
                 public void run() {
-                    listener.onCardSwiped(direction);
+                    listener.onCardSwiped(direction, swipedPosition);
                     View topView = getTopView();
                     if (topView != null) {
                         listener.onCardAppeared(getTopView(), state.topPosition);

--- a/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackListener.java
+++ b/cardstackview/src/main/java/com/yuyakaido/android/cardstackview/CardStackListener.java
@@ -4,7 +4,7 @@ import android.view.View;
 
 public interface CardStackListener {
     void onCardDragging(Direction direction, float ratio);
-    void onCardSwiped(Direction direction);
+    void onCardSwiped(Direction direction, int swipedPosition);
     void onCardRewound();
     void onCardCanceled();
     void onCardAppeared(View view, int position);
@@ -14,7 +14,7 @@ public interface CardStackListener {
         @Override
         public void onCardDragging(Direction direction, float ratio) {}
         @Override
-        public void onCardSwiped(Direction direction) {}
+        public void onCardSwiped(Direction direction, int swipedPosition) {}
         @Override
         public void onCardRewound() {}
         @Override

--- a/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/MainActivity.kt
+++ b/sample/src/main/java/com/yuyakaido/android/cardstackview/sample/MainActivity.kt
@@ -45,9 +45,9 @@ class MainActivity : AppCompatActivity(), CardStackListener {
         Log.d("CardStackView", "onCardDragging: d = ${direction.name}, r = $ratio")
     }
 
-    override fun onCardSwiped(direction: Direction) {
-        Log.d("CardStackView", "onCardSwiped: p = ${manager.topPosition}, d = $direction")
-        if (manager.topPosition == adapter.itemCount - 5) {
+    override fun onCardSwiped(direction: Direction, swipedPosition: Int) {
+        Log.d("CardStackView", "onCardSwiped: p = $swipedPosition, d = $direction")
+        if (swipedPosition == adapter.itemCount - 5) {
             paginate()
         }
     }


### PR DESCRIPTION
Whenever a card is swiped, this also captures the position
of the swiped card and emits it to the event. This allows
us to trust the position at the event handler, and not have
to inspect the cardLayoutManager directly. This is helpful
in the case where our event may trigger another runnable or
otherwise may not be able to trust that the layoutManager
has not already calculated another topPosition.